### PR TITLE
Add flow selection overlay

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -3,6 +3,9 @@
 import { useEffect } from 'react'
 import Background from '@/components/Background'
 import InteractionHubEnhanced from '@/components/core/InteractionHubEnhanced'
+import { Button } from '@/components/ui/button'
+import { useUIStore } from '@/store'
+import { ListTree } from 'lucide-react'
 
 
 export default function Home() {
@@ -29,6 +32,23 @@ export default function Home() {
       <div className="absolute bottom-18 w-full left-1/2 transform -translate-x-1/2 z-0 max-w-xl px-4">
         <InteractionHubEnhanced />
       </div>
+
+      <FlowSelectButton />
     </div>
   )
+}
+
+function FlowSelectButton() {
+  const toggleFlowSelectOverlay = useUIStore((state) => state.toggleFlowSelectOverlay);
+  return (
+    <Button
+      variant="default"
+      size="icon"
+      className="fixed bottom-4 right-4 z-10 rounded-full shadow-lg"
+      onClick={() => toggleFlowSelectOverlay(true)}
+    >
+      <ListTree className="h-6 w-6" />
+      <span className="sr-only">Start a flow</span>
+    </Button>
+  );
 }

--- a/components/core/InteractionHubEnhanced.tsx
+++ b/components/core/InteractionHubEnhanced.tsx
@@ -44,6 +44,8 @@ export default function InteractionHubVoice() {
         warmth,
         challenge,
         isOptedInToConnect,
+        startFlowId,
+        setStartFlowId,
         checkPhq4Overlay,
     } = useUIStore();
     
@@ -818,16 +820,20 @@ export default function InteractionHubVoice() {
         }
     }, [useLocalLingo]);
 
-    const sendImprovMessage = useCallback(() => {
+    const sendFlowMessage = useCallback((flow: string) => {
         if (ws.current?.readyState === WebSocket.OPEN) {
-            const improvMessage: ImprovMessage = {
+            const message: ImprovMessage = {
                 type: "improv",
-                improv_form_name: "connect",
+                improv_form_name: flow,
                 user_input: lastUserInput
             };
-            ws.current.send(JSON.stringify(improvMessage));
+            ws.current.send(JSON.stringify(message));
         }
     }, [lastUserInput]);
+
+    const sendImprovMessage = useCallback(() => {
+        sendFlowMessage("connect");
+    }, [sendFlowMessage]);
 
     // Add effect to scroll to bottom when content changes
     useEffect(() => {
@@ -889,6 +895,14 @@ export default function InteractionHubVoice() {
             sendImprovMessage();
         }
     }, [isOptedInToConnect, sendImprovMessage]);
+
+    // Trigger selected flow
+    useEffect(() => {
+        if (startFlowId) {
+            sendFlowMessage(startFlowId);
+            setStartFlowId(null);
+        }
+    }, [startFlowId, sendFlowMessage, setStartFlowId]);
 
 
     return (

--- a/components/core/InteractionHubEnhanced.tsx
+++ b/components/core/InteractionHubEnhanced.tsx
@@ -825,7 +825,7 @@ export default function InteractionHubVoice() {
             const message: ImprovMessage = {
                 type: "improv",
                 improv_form_name: flow,
-                user_input: lastUserInput
+                user_input: `Start the ${flow} flow`
             };
             ws.current.send(JSON.stringify(message));
         }
@@ -882,7 +882,7 @@ export default function InteractionHubVoice() {
         }
     }, [connected, sendPersonality]);
 
-    // NEW: Effect to send local lingo status when it changes and connection is active
+    // Effect to send local lingo status when it changes and connection is active
     useEffect(() => {
         if (connected) {
             sendLocalLingoMessage();

--- a/components/layout/RenderOverlays.tsx
+++ b/components/layout/RenderOverlays.tsx
@@ -19,6 +19,7 @@ import CaptureOverlay from '@/components/overlays/CaptureOverlay';
 import PushNotificationOverlay from '@/components/overlays/PushNotificationsOverlay';
 import ConnectProfileOverlay from '@/components/overlays/ConnectProfileOverlay';
 import Phq4Overlay from '@/components/overlays/Phq4Overlay';
+import FlowSelectOverlay from '@/components/overlays/FlowSelectOverlay';
 
 // import SettingsOverlay from '@/components/overlays/SettingsOverlay'; // Uncomment when ready
 
@@ -33,6 +34,7 @@ export function RenderOverlays() {
     const isCaptureOpen = useUIStore((state) => state.isCaptureOpen);
     const isNotificationsOpen = useUIStore((state) => state.isNotificationsOpen);
     const isConnectFormOpen = useUIStore((state) => state.isConnectFormOpen);
+    const isFlowSelectOpen = useUIStore((state) => state.isFlowSelectOpen);
     const isPhq4Open = useUIStore((state) => state.isPhq4Open);
 
     const toggleAuthOverlay = useUIStore((state) => state.toggleAuthOverlay);
@@ -44,6 +46,7 @@ export function RenderOverlays() {
     const toggleCaptureOverlay = useUIStore((state) => state.toggleCaptureOverlay);
     const toggleNotificationsOverlay = useUIStore((state) => state.toggleNotificationsOverlay);
     const toggleConnectFormOverlay = useUIStore((state) => state.toggleConnectFormOverlay);
+    const toggleFlowSelectOverlay = useUIStore((state) => state.toggleFlowSelectOverlay);
     const togglePhq4Overlay = useUIStore((state) => state.togglePhq4Overlay);
 
     // Get session status
@@ -83,6 +86,7 @@ export function RenderOverlays() {
             <PushNotificationOverlay open={isNotificationsOpen} onOpenChange={toggleNotificationsOverlay} />
             <ConnectProfileOverlay open={isConnectFormOpen} onOpenChange={toggleConnectFormOverlay} />
             <Phq4Overlay isOpen={isPhq4Open} stage="pre" onClose={() => togglePhq4Overlay(false)} onSubmit={() => {}} />
+            <FlowSelectOverlay open={isFlowSelectOpen} onOpenChange={toggleFlowSelectOverlay} />
             {/* <SettingsOverlay open={isSettingsOpen} onOpenChange={toggleSettingsOverlay} /> */}
         </>
     );

--- a/components/overlays/FlowSelectOverlay.tsx
+++ b/components/overlays/FlowSelectOverlay.tsx
@@ -5,6 +5,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '
 import { Button } from '@/components/ui/button';
 import { getMultistepFlows } from '@/lib/api/flows';
 import { useUIStore } from '@/store';
+import { toast } from 'sonner';
 
 interface FlowSelectOverlayProps {
   open: boolean;
@@ -20,9 +21,12 @@ export default function FlowSelectOverlay({ open, onOpenChange }: FlowSelectOver
     enabled: open,
   });
 
-  const handleSelect = (id: string) => {
+  const handleSelect = (id: string, flowName?: string) => {
     setStartFlowId(id);
     onOpenChange(false);
+    
+    // Provide user feedback that the flow is starting
+    toast.info(`Starting flow: ${flowName || id}`);
   };
 
   return (
@@ -37,7 +41,12 @@ export default function FlowSelectOverlay({ open, onOpenChange }: FlowSelectOver
           {error && <p className="text-destructive">Failed to load flows</p>}
           {data &&
             Object.entries(data).map(([id, flow]: [string, any]) => (
-              <Button key={id} variant="outline" className="w-full justify-start" onClick={() => handleSelect(id)}>
+              <Button 
+                key={id} 
+                variant="outline" 
+                className="w-full justify-start" 
+                onClick={() => handleSelect(id, flow?.name || flow?.title)}
+              >
                 {flow?.name || flow?.title || id}
               </Button>
             ))}

--- a/components/overlays/FlowSelectOverlay.tsx
+++ b/components/overlays/FlowSelectOverlay.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { getMultistepFlows } from '@/lib/api/flows';
+import { useUIStore } from '@/store';
+
+interface FlowSelectOverlayProps {
+  open: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+}
+
+export default function FlowSelectOverlay({ open, onOpenChange }: FlowSelectOverlayProps) {
+  const setStartFlowId = useUIStore((state) => state.setStartFlowId);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['multistep-flows'],
+    queryFn: getMultistepFlows,
+    enabled: open,
+  });
+
+  const handleSelect = (id: string) => {
+    setStartFlowId(id);
+    onOpenChange(false);
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="sm:max-w-md flex flex-col">
+        <SheetHeader className="border-b pb-4 pt-2">
+          <SheetTitle>Select a Flow</SheetTitle>
+          <SheetDescription>Choose a flow to start</SheetDescription>
+        </SheetHeader>
+        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          {isLoading && <p>Loading...</p>}
+          {error && <p className="text-destructive">Failed to load flows</p>}
+          {data &&
+            Object.entries(data).map(([id, flow]: [string, any]) => (
+              <Button key={id} variant="outline" className="w-full justify-start" onClick={() => handleSelect(id)}>
+                {flow?.name || flow?.title || id}
+              </Button>
+            ))}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/lib/api/flows.ts
+++ b/lib/api/flows.ts
@@ -14,7 +14,7 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
 
 export async function getMultistepFlows(): Promise<Record<string, any>> {
   const headers = await getAuthHeaders();
-  const res = await fetch(`${BACKEND_URL}/flows`, { headers });
+  const res = await fetch(`${BACKEND_URL}/multistep/flows`, { headers });
   if (!res.ok) {
     throw new Error('Failed to fetch flows');
   }

--- a/lib/api/flows.ts
+++ b/lib/api/flows.ts
@@ -1,0 +1,22 @@
+import { getSession } from 'next-auth/react';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  const session = await getSession();
+  const accessToken = session?.user?.accessToken;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (accessToken) {
+    headers['Authorization'] = `Bearer ${accessToken}`;
+  }
+  return headers;
+}
+
+export async function getMultistepFlows(): Promise<Record<string, any>> {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${BACKEND_URL}/flows`, { headers });
+  if (!res.ok) {
+    throw new Error('Failed to fetch flows');
+  }
+  return res.json();
+}

--- a/store/index.ts
+++ b/store/index.ts
@@ -18,6 +18,8 @@ interface UIState {
     isCaptureOpen: boolean;
     isNotificationsOpen: boolean;
     isConnectFormOpen: boolean;
+    isFlowSelectOpen: boolean;
+    startFlowId: string | null;
     useLocalLingo: boolean;
 
 
@@ -55,6 +57,8 @@ interface UIState {
     toggleCaptureOverlay: (isOpen: boolean) => void;
     toggleNotificationsOverlay: (isOpen: boolean) => void;
     toggleConnectFormOverlay: (isOpen: boolean) => void;
+    toggleFlowSelectOverlay: (isOpen?: boolean) => void;
+    setStartFlowId: (flowId: string | null) => void;
     toggleLocalLingo: (isOn: boolean) => void;
 
     toggleOptedInToCare: (isOptedInToCare: boolean) => void;
@@ -93,6 +97,8 @@ export const useUIStore = create<UIState>()(
             isCaptureOpen: false,
             isNotificationsOpen: false,
             isConnectFormOpen: false,
+            isFlowSelectOpen: false,
+            startFlowId: null,
             useLocalLingo: false,
 
             // PHQ-4
@@ -171,6 +177,12 @@ export const useUIStore = create<UIState>()(
             toggleConnectFormOverlay: (isOpen) => set((state) => ({
                 isConnectFormOpen: isOpen !== undefined ? isOpen : !state.isConnectFormOpen
             })),
+
+            toggleFlowSelectOverlay: (isOpen) => set((state) => ({
+                isFlowSelectOpen: isOpen !== undefined ? isOpen : !state.isFlowSelectOpen
+            })),
+
+            setStartFlowId: (flowId) => set({ startFlowId: flowId }),
 
             toggleLocalLingo: (useLocalLingo) => set((state) => ({
                 useLocalLingo: useLocalLingo !== undefined ? useLocalLingo : !state.useLocalLingo


### PR DESCRIPTION
## Summary
- add API helper to fetch available flows
- store state to trigger flows and display flow selector overlay
- implement `FlowSelectOverlay` with `Sheet`
- show overlay from `RenderOverlays`
- add floating button on main page to open flow selector
- send selected flow via websocket in `InteractionHubEnhanced`

## Testing
- `npm run lint` *(fails: `next` not found)*