### PR TITLE
Implement onboarding flow skeleton

### DIFF
--- a/app/api/onboarding/update/route.ts
+++ b/app/api/onboarding/update/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.accessToken) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: { screen_id?: number; response?: unknown; complete?: boolean };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+  }
+
+  try {
+    const res = await fetch(`${BACKEND_URL}/onboarding/update`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.user.accessToken}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json().catch(() => ({ error: 'Invalid response' }));
+
+    if (!res.ok) {
+      console.error('Onboarding update error:', data);
+      return NextResponse.json(data, { status: res.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Onboarding update failed:', error);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { OnboardingFlowProvider, useOnboardingFlow } from '@/hooks/useOnboardingFlow';
+import { Screen1, Screen2, Screen3, Screen4, Screen5, Screen6, Screen7, Screen8, Screen9, Screen10 } from '@/components/onboarding/screens';
+
+const screens = [
+  Screen1,
+  Screen2,
+  Screen3,
+  Screen4,
+  Screen5,
+  Screen6,
+  Screen7,
+  Screen8,
+  Screen9,
+  Screen10,
+];
+
+function Renderer() {
+  const { screenId } = useOnboardingFlow();
+  const Screen = screens[screenId - 1] ?? Screen1;
+  return <Screen />;
+}
+
+export default function OnboardingPage() {
+  return (
+    <OnboardingFlowProvider>
+      <Renderer />
+    </OnboardingFlowProvider>
+  );
+}

--- a/components/onboarding/screens.tsx
+++ b/components/onboarding/screens.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useOnboardingFlow } from '@/hooks/useOnboardingFlow';
+
+interface InputScreenProps {
+  id: number;
+  question: string;
+  complete?: boolean;
+  textarea?: boolean;
+}
+
+function InputScreen({ id, question, complete, textarea }: InputScreenProps) {
+  const { submitAnswer } = useOnboardingFlow();
+  const [value, setValue] = useState('');
+  const Field = textarea ? Textarea : Input;
+
+  return (
+    <div className="min-h-screen flex flex-col justify-between p-4">
+      <div className="flex-1">
+        <p className="mb-4 text-lg">{question}</p>
+        <Field
+          value={value}
+          onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+            setValue(e.target.value)
+          }
+        />
+      </div>
+      <Button className="mt-6" onClick={() => submitAnswer(id, value, complete)}>
+        {complete ? 'Finish' : 'Next'}
+      </Button>
+    </div>
+  );
+}
+
+export function Screen1() {
+  return <InputScreen id={1} question="What's your name?" />;
+}
+export function Screen2() {
+  return <InputScreen id={2} question="How old are you?" />;
+}
+export function Screen3() {
+  return <InputScreen id={3} question="Where do you live?" />;
+}
+export function Screen4() {
+  return <InputScreen id={4} question="What's your favorite hobby?" />;
+}
+export function Screen5() {
+  return <InputScreen id={5} question="How did you hear about us?" />;
+}
+export function Screen6() {
+  return <InputScreen id={6} question="What's your primary goal with Knolia?" textarea />;
+}
+export function Screen7() {
+  return <InputScreen id={7} question="Would you like notifications?" />;
+}
+export function Screen8() {
+  return <InputScreen id={8} question="Pick a preferred color theme" />;
+}
+export function Screen9() {
+  return <InputScreen id={9} question="Share one fun fact about yourself" textarea />;
+}
+export function Screen10() {
+  return <InputScreen id={10} question="Ready to start?" complete />;
+}

--- a/hooks/useOnboardingFlow.ts
+++ b/hooks/useOnboardingFlow.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+interface ResponseMap {
+  [key: number]: any;
+}
+
+interface OnboardingFlowContextValue {
+  screenId: number;
+  responses: ResponseMap;
+  next: () => void;
+  prev: () => void;
+  submitAnswer: (id: number, response: any, complete?: boolean) => Promise<void>;
+}
+
+const OnboardingFlowContext = createContext<OnboardingFlowContextValue | null>(null);
+
+export function OnboardingFlowProvider({ children }: { children: ReactNode }) {
+  const [screenId, setScreenId] = useState(1);
+  const [responses, setResponses] = useState<ResponseMap>({});
+
+  const next = () => setScreenId((id) => Math.min(id + 1, 10));
+  const prev = () => setScreenId((id) => Math.max(id - 1, 1));
+
+  const submitAnswer = async (id: number, response: any, complete?: boolean) => {
+    setResponses((prev) => ({ ...prev, [id]: response }));
+    try {
+      await fetch('/api/onboarding/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ screen_id: id, response, complete }),
+      });
+    } catch (err) {
+      console.error('Failed to update onboarding:', err);
+    }
+    if (!complete) next();
+  };
+
+  return (
+    <OnboardingFlowContext.Provider value={{ screenId, responses, next, prev, submitAnswer }}>
+      {children}
+    </OnboardingFlowContext.Provider>
+  );
+}
+
+export function useOnboardingFlow() {
+  const ctx = useContext(OnboardingFlowContext);
+  if (!ctx) {
+    throw new Error('useOnboardingFlow must be used within OnboardingFlowProvider');
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add `useOnboardingFlow` hook and provider for onboarding state
- create API route that proxies onboarding answers to the backend
- implement simple onboarding screens and renderer page

## Testing
- `npm run lint`